### PR TITLE
fix(bug): serializable generator recipe

### DIFF
--- a/src/model/generatorRecipe.ts
+++ b/src/model/generatorRecipe.ts
@@ -18,7 +18,7 @@ export class GeneratorRecipe {
     * Length of the generated value
     */
     'length'?: number;
-    'characterSets'?: Set<GeneratorRecipe.CharacterSetsEnum>;
+    'characterSets'?: Array<GeneratorRecipe.CharacterSetsEnum>;
 
     static discriminator: string | undefined = undefined;
 


### PR DESCRIPTION
Using a JavaScript 'Set' is not serializable with JSON.stringify.
Change the Password GeneratorRecipe.characterSets enum to 'Array'.