### PR TITLE
fix(bug): make GeneratorRecipe.characterSets serializable

### DIFF
--- a/__test__/itembuilder.test.ts
+++ b/__test__/itembuilder.test.ts
@@ -9,12 +9,12 @@ describe("Test ItemBuilder", () => {
     // @ts-expect-error
     const invalidRecipe = {
         length: 6,
-        characterSets: new Set(["adfioadhfg"]),
+        characterSets: ["adfioadhfg"],
     } as GeneratorRecipe;
 
     const validRecipe = {
         length: 6,
-        characterSets: new Set([GeneratorRecipe.CharacterSetsEnum.Digits]),
+        characterSets: [GeneratorRecipe.CharacterSetsEnum.Digits],
     } as GeneratorRecipe;
 
     test("Create Item with minimum required fields", () => {
@@ -188,7 +188,7 @@ describe("Test ItemBuilder", () => {
         const fieldSectionName = "Test Section";
 
         const item = new ItemBuilder()
-            .setCategory(CategoryEnum.Login) 
+            .setCategory(CategoryEnum.Login)
             .addField({value: "MySecret", sectionName: fieldSectionName})
             .build();
 

--- a/src/lib/builders.ts
+++ b/src/lib/builders.ts
@@ -200,7 +200,7 @@ export class ItemBuilder {
         this.item.category = category as FullItem.CategoryEnum;
         return this;
     }
-    
+
     /**
      * Creates a new Item Section if it does not exist. Otherwise, return the previously-created
      * Item Section.
@@ -236,14 +236,14 @@ export class ItemBuilder {
  * @returns {boolean}
  */
 const validRecipe = (recipe: GeneratorRecipe): boolean => {
-    if (!recipe.characterSets || !recipe.characterSets.size) return true;
+    if (!recipe.characterSets || !recipe.characterSets.length) return true;
 
     const allowedCharactersSets = Object.values(
         GeneratorRecipe.CharacterSetsEnum,
     );
 
     // User provided more character sets than are defined
-    if (recipe.characterSets.size > allowedCharactersSets.length) return false;
+    if (recipe.characterSets.length > allowedCharactersSets.length) return false;
 
     for (const cs of recipe.characterSets) {
         if (allowedCharactersSets.indexOf(cs) === -1) {

--- a/src/model/generatorRecipe.ts
+++ b/src/model/generatorRecipe.ts
@@ -18,7 +18,7 @@ export class GeneratorRecipe {
     * Length of the generated value
     */
     'length'?: number;
-    'characterSets'?: Set<GeneratorRecipe.CharacterSetsEnum>;
+    'characterSets'?: GeneratorRecipe.CharacterSetsEnum[];
 
     static discriminator: string | undefined = undefined;
 


### PR DESCRIPTION
Using a JavaScript 'Set' is not serializable with JSON.stringify.
Change the Password GeneratorRecipe.characterSets enum to 'Array'.